### PR TITLE
Update trollop to optimist & add new option to include remainder rows in a new CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ This script has seven (7) parameters:
 
 ```
 Options:
-	 --file-path  <path/name.cvs>             : Path to csv file to be split
-     --new_file_name <path/name.cvs>        : Allow user to change name of processed split files
-	 --include-headers, --no-include-headers  : Include headers in new files (default: true)
-	 --line-count <number>                    : Number of lines per file (default: 2500)
-     --delimiter <delimiter>                : Allows user to change comma delimited to another Character
-     --remove_columns                       : After split it performed, loads remove.csv, creates 2nd directory process split files rmoving those columns
-     --help, -h                             : Show this message
+  --file-path  <path/name.csv>            : Path to csv file to be split
+  --new_file_name <path/name.csv>         : Allow user to change name of processed split files
+  --include-headers, --no-include-headers : Include headers in new files (default: true)
+  --line-count <number>                   : Number of lines per file (default: 2500)
+  --delimiter <delimiter>                 : Allows user to change comma delimited to another Character
+  --remove_columns                        : After split it performed, loads remove.csv, creates 2nd directory process split files removing those columns
+  --help, -h                              : Show this message
 ```
 
 ## Required Gems
@@ -25,15 +25,12 @@ Options:
 
 1. Clone repository
 2. Install the required gem:
-
 	```
 	gem install optimist
-
 	```
 
 ## Running the script
 
 ```
 ruby csv-split.rb --file-path path/to/csv/file/.csv --line-count 2500 --include-headers
-
 ```

--- a/README.md
+++ b/README.md
@@ -1,33 +1,34 @@
-#CSV Split
+# CSV Split
 
 Developed and tested on Ruby 2.4.0
 
-A ruby script that splits a large csv file into smaller files and stores the smaller files into the ```converted-files``` directory.
+A ruby script that splits a large csv file into smaller files and stores the smaller files into the ```split-files``` directory.
 
-This script has sevin (7) parameters:
+This script has seven (7) parameters:
 
 ```
 Options:
-	 --file-path  <path/name.cvs> 			   :    Path to csv file to be split
-     --new_file_name <path/name.cvs>   		   :	Allow user to change name of processed split files
-	 --include-headers, --no-include-headers   :    Include headers in new files (default: true)
-	 --line-count <number> 					   :	Number of lines per file (default: 2500)
-     --delimiter <delimiter>	   			   :    Allows user to change comma delimited to another Character
-     --remove_columns                          : 	After split it performed, loads remove.csv, creates 2nd directory process split files rmoving those columns
-     --help, -h:   Show this message
+	 --file-path  <path/name.cvs>             : Path to csv file to be split
+     --new_file_name <path/name.cvs>        : Allow user to change name of processed split files
+	 --include-headers, --no-include-headers  : Include headers in new files (default: true)
+	 --line-count <number>                    : Number of lines per file (default: 2500)
+     --delimiter <delimiter>                : Allows user to change comma delimited to another Character
+     --remove_columns                       : After split it performed, loads remove.csv, creates 2nd directory process split files rmoving those columns
+     --help, -h                             : Show this message
 ```
 
 ## Required Gems
-- trollop
+
+- [optimist](https://github.com/ManageIQ/optimist)
 
 ## Installation
 
 1. Clone repository
-2. Install required gem:
-		
-	``` 
-	gem install trollop 
-	
+2. Install the required gem:
+
+	```
+	gem install optimist
+
 	```
 
 ## Running the script
@@ -36,4 +37,3 @@ Options:
 ruby csv-split.rb --file-path path/to/csv/file/.csv --line-count 2500 --include-headers
 
 ```
-

--- a/README.md
+++ b/README.md
@@ -4,17 +4,18 @@ Developed and tested on Ruby 2.4.0
 
 A ruby script that splits a large csv file into smaller files and stores the smaller files into the ```split-files``` directory.
 
-This script has seven (7) parameters:
+This script has eight parameters:
 
 ```
 Options:
-  --file-path  <path/name.csv>            : Path to csv file to be split
-  --new_file_name <path/name.csv>         : Allow user to change name of processed split files
-  --include-headers, --no-include-headers : Include headers in new files (default: true)
-  --line-count <number>                   : Number of lines per file (default: 2500)
-  --delimiter <delimiter>                 : Allows user to change comma delimited to another Character
-  --remove_columns                        : After split it performed, loads remove.csv, creates 2nd directory process split files removing those columns
-  --help, -h                              : Show this message
+  -f, --file-path=<s>                         Path to csv file to be split
+  -n, --new-file-name=<s>                     Name of the new files. This will be appended with an incremented number (default: split)
+  -i, --include-headers, --no-include-headers Include headers in new files (default: true)
+  -l, --line-count=<i>                        Number of lines per file (default: 1)
+  -d, --delimiter=<s>                         Charcter used for Col. Sep. (Default: ,)
+  -r, --remove-columns                        Specify column names to be removed during processing in remove_coluns.txt
+  -c, --include-remainders                    Include remainder rows in the split files (default: false). Example: if there are 1030 rows in a csv file and will be split in 100 rows, the remaining 30 rows will be stored in a new file
+  -h, --help                                  Show this message
 ```
 
 ## Required Gems

--- a/csv-split.rb
+++ b/csv-split.rb
@@ -1,6 +1,6 @@
-require 'trollop'
+require 'optimist'
 require 'fileutils'  #Added for file management
-require 'csv'	     
+require 'csv'
 
 # I want to deeply thank https://github.com/imartingraham for providing this original work
 #
@@ -13,13 +13,13 @@ require 'csv'
 # Regards wb 0727/2017
 #
 
-opts = Trollop::options do
+opts = Optimist::options do
   opt :file_path, "Path to csv file to be split", type: :string, default: nil
   opt :new_file_name, "Name of the new files. This will be appended with an incremented number", type: :string, default: 'split' #Please note later i change the default name to {original_filename}-{inc#}.csv
   opt :include_headers, "Include headers in new files", default: true, type: :boolean
   opt :line_count, "Number of lines per file", default: 1, type: :integer #change default to 1
   opt :delimiter, "Charcter used for Col. Sep.", default: ',', type: :string #Add custom delimiter
-  opt :remove_columns, "Specify column names to be removed during processing in remove_coluns.txt", default: false, type: :boolean #Add Remove Column processing with remove.csv
+	opt :remove_columns, "Specify column names to be removed during processing in remove_coluns.txt", default: false, type: :boolean #Add Remove Column processing with remove.csv
 end
 
 #Remind users to provide ARGVs at command-line
@@ -67,8 +67,7 @@ else
 	s = opts[:new_file_name]
 	s_name = s.split('/')[-1] #Sanitizing incase user adds a path but overkill
 	split_name = s_name.split('.')[0]
-end 
-
+end
 
 
 file = File.expand_path(opts[:file_path])
@@ -87,7 +86,7 @@ CSV.foreach(file, {headers: true, encoding: "UTF-8", quote_char: '"', col_sep: o
   col_data << row
   if index % opts[:line_count] == 0
     CSV.open(new_file, "wb", force_quotes: true) do |csv|
-      
+
       if opts[:include_headers]
         csv << headers
       end
@@ -109,7 +108,7 @@ end
 #Added se the ability to process the split files (leaving original split files) and removing columns
 
 if opts[:remove_columns] == true
-	
+
 	#Clean-up previous processing and create new directory fo rthe split files with columns removed
 	split_path_name_rmv_cols = "split-files-rmv-cols"
 	if File.exists?(split_path_name_rmv_cols)
@@ -118,31 +117,31 @@ if opts[:remove_columns] == true
 	else
 		FileUtils.mkdir_p "#{path_name}/#{split_path_name_rmv_cols}"
 	end
-	
+
 	Dir.glob("#{path_name}/#{split_path_name}/*.csv") do |csv_name|
-		
+
 		original = CSV.read(csv_name, { headers: true, return_headers: true, encoding: "UTF-8", quote_char: '"', col_sep: opts[:delimiter] })
 
 		rmv_col_names =[]
 		rmvr = 0
-		
-		list = CSV.foreach('remove.csv', {headers: true, encoding: "UTF-8", quote_char: '"', col_sep:","}) do |row|	
-			rmv_col_names << row[0] 
+
+		list = CSV.foreach('remove.csv', {headers: true, encoding: "UTF-8", quote_char: '"', col_sep:","}) do |row|
+			rmv_col_names << row[0]
 		end
-		
+
 		rmv_col_count = rmv_col_names.count
-		
-		while rmvr < (rmv_col_count-1)	      
+
+		while rmvr < (rmv_col_count-1)
 			original.delete("#{rmv_col_names[rmvr]}")
 			rmvr +=1
 		end
-								
-		csv_rmv_name = csv_name.split('/')[-1]	
-			
+
+		csv_rmv_name = csv_name.split('/')[-1]
+
 		CSV.open("#{path_name}/#{split_path_name_rmv_cols}/#{csv_rmv_name}", 'w') do |csv|
 		  original.each do |row|
 		    csv << row
 		  end
 		end
 	end
-end	
+end


### PR DESCRIPTION
Hello!
First of all, thanks for the project!
Probably by now, the source repo is already unmaintained. But I recently used this a lot to split large CSV files and it is really helpful.

I made some updates to my forked version of the repo for personal use, but I thought maybe this would be useful to be included in the main one.
The updates are:
- Reformatted the README and the script itself
- Updated the `trollop` gem to use `optimist` instead (trollop has been changed to optimist)
- Added a new option, `--include-remainders` to include excess rows from the source CSV in a new split CSV file, adding the last number of the default split CSV file.